### PR TITLE
Add options "bodyParserLimit" to change bodyParser limit

### DIFF
--- a/src/express/app-builder.js
+++ b/src/express/app-builder.js
@@ -27,9 +27,9 @@ function expressToLambdaHandler(app) {
 /**
  * @private
  */
-function expressToBodyParser() {
+function expressToBodyParser(bodyParserLimit) {
   const bodyParserOptions = {
-    limit: '10mb',
+    limit: bodyParserLimit || '10mb',
   };
 
   return bodyParser.json(bodyParserOptions);
@@ -39,7 +39,7 @@ function expressToBodyParser() {
  * @private
  */
 function setupAppMiddlewares(app, options) {
-  app.use(expressToBodyParser());
+  app.use(expressToBodyParser(options.bodyParserLimit));
   app.use(expressContextMiddleware);
   app.use(expressLoggingMiddleware);
   app.use(expressCorsMiddleware());


### PR DESCRIPTION
## Summary
"bodyParserLimit" option to set another bodyParser limit

### Proposed changes
The bodyParserLimit is '10mb'. This options will be used to change this value when necessary.

This PR brings the following changes:

- Use option 'bodyParserLimit' in 'expressToBodyParser' function.

### Related issue

Not applicable

### Dependencies added/removed (if applicable)

Not Applicable
---

### Testing

Not Applicable

#### How to test

Describe the tests that you ran to verify your changes:

1. npm test

#### Test configuration

Not Applicable

---

## Checklist

- [ ] I have added corresponding labels to this PR (like bug, enhancement...);
- [X] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [X] My code follows the style guidelines of this project;
- [X] I have performed a self-review of my own code;
- [X] I have mapped technical debts found on my changes;
- [ ] I have made corresponding changes to the documentation (if applicable);
- [X] My changes generate no new warnings or errors;
